### PR TITLE
gh-following 1.1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 
-# gh-following [![PayPal](https://img.shields.io/badge/%24-paypal-f39c12.svg)][paypal-donations] [![Version](https://img.shields.io/npm/v/gh-following.svg)](https://www.npmjs.com/package/gh-following) [![Downloads](https://img.shields.io/npm/dt/gh-following.svg)](https://www.npmjs.com/package/gh-following) [![Get help on Codementor](https://cdn.codementor.io/badges/get_help_github.svg)](https://www.codementor.io/johnnyb?utm_source=github&utm_medium=button&utm_term=johnnyb&utm_campaign=github)
+# gh-following
+
+ [![PayPal](https://img.shields.io/badge/%24-paypal-f39c12.svg)][paypal-donations] [![AMA](https://img.shields.io/badge/ask%20me-anything-1abc9c.svg)](https://github.com/IonicaBizau/ama) [![Version](https://img.shields.io/npm/v/gh-following.svg)](https://www.npmjs.com/package/gh-following) [![Downloads](https://img.shields.io/npm/dt/gh-following.svg)](https://www.npmjs.com/package/gh-following) [![Get help on Codementor](https://cdn.codementor.io/badges/get_help_github.svg)](https://www.codementor.io/johnnyb?utm_source=github&utm_medium=button&utm_term=johnnyb&utm_campaign=github)
 
 > Fetches the users you follow but they don't follow you and the users that follow you but you don't.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gh-following",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Fetches the users you follow but they don't follow you and the users that follow you but you don't.",
   "main": "lib/index.js",
   "scripts": {
@@ -34,6 +34,7 @@
     "src/",
     "resources/",
     "menu/",
+    "scripts/",
     "cli.js",
     "index.js"
   ]


### PR DESCRIPTION
- Updated the README.md following the new template. :memo:
- Use [`babel-it`](https://github.com/IonicaBizau/babel-it) to babelify the code, so the module is now compatible with older versions of Node.js.
